### PR TITLE
feat(transactions): filter pre-fill and future date warning in Add Transaction dialog

### DIFF
--- a/src/app/transactions/add-transaction-form.test.ts
+++ b/src/app/transactions/add-transaction-form.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { MAX_TRANSACTION_NOTE_LENGTH } from "@/lib/transactions/note";
-import { validateAddForm } from "./add-transaction-form";
+import {
+  buildInitialAddForm,
+  isFutureDate,
+  validateAddForm,
+} from "./add-transaction-form";
+import { UNCATEGORIZED_VALUE } from "./transactions-manager.types";
 
 function baseForm() {
   return {
@@ -112,5 +117,92 @@ describe("validateAddForm", () => {
       note: "a".repeat(MAX_TRANSACTION_NOTE_LENGTH),
     });
     expect(result.valid).toBe(true);
+  });
+});
+
+describe("buildInitialAddForm", () => {
+  it("returns empty accountId when no accountId filter", () => {
+    const form = buildInitialAddForm({
+      accountId: "",
+      categoryId: "",
+      dateFrom: "",
+    });
+    expect(form.accountId).toBe("");
+  });
+
+  it("pre-fills accountId from active filter", () => {
+    const form = buildInitialAddForm({
+      accountId: "acc-1",
+      categoryId: "",
+      dateFrom: "",
+    });
+    expect(form.accountId).toBe("acc-1");
+  });
+
+  it("returns UNCATEGORIZED_VALUE when no categoryId filter", () => {
+    const form = buildInitialAddForm({
+      accountId: "",
+      categoryId: "",
+      dateFrom: "",
+    });
+    expect(form.categoryId).toBe(UNCATEGORIZED_VALUE);
+  });
+
+  it("pre-fills categoryId from active filter", () => {
+    const form = buildInitialAddForm({
+      accountId: "",
+      categoryId: "cat-1",
+      dateFrom: "",
+    });
+    expect(form.categoryId).toBe("cat-1");
+  });
+
+  it("returns empty bookingDate when no dateFrom filter", () => {
+    const form = buildInitialAddForm({
+      accountId: "",
+      categoryId: "",
+      dateFrom: "",
+    });
+    expect(form.bookingDate).toBe("");
+  });
+
+  it("pre-fills bookingDate from dateFrom filter", () => {
+    const form = buildInitialAddForm({
+      accountId: "",
+      categoryId: "",
+      dateFrom: "2026-03-01",
+    });
+    expect(form.bookingDate).toBe("2026-03-01");
+  });
+
+  it("returns all other fields with empty/default values", () => {
+    const form = buildInitialAddForm({
+      accountId: "",
+      categoryId: "",
+      dateFrom: "",
+    });
+    expect(form.amountNok).toBe("");
+    expect(form.merchant).toBe("");
+    expect(form.paymentType).toBe("OTHER");
+    expect(form.note).toBe("");
+  });
+});
+
+describe("isFutureDate", () => {
+  it("returns true for a clearly future date", () => {
+    expect(isFutureDate("2099-01-01")).toBe(true);
+  });
+
+  it("returns false for a clearly past date", () => {
+    expect(isFutureDate("2020-01-01")).toBe(false);
+  });
+
+  it("returns false for today", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    expect(isFutureDate(today)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isFutureDate("")).toBe(false);
   });
 });

--- a/src/app/transactions/add-transaction-form.ts
+++ b/src/app/transactions/add-transaction-form.ts
@@ -2,7 +2,10 @@ import {
   MAX_TRANSACTION_NOTE_LENGTH,
   MAX_TRANSACTION_NOTE_LENGTH_MESSAGE,
 } from "@/lib/transactions/note";
-import type { AddFormState } from "./transactions-manager.types";
+import {
+  type AddFormState,
+  UNCATEGORIZED_VALUE,
+} from "./transactions-manager.types";
 
 type ValidAddForm = {
   valid: true;
@@ -19,6 +22,30 @@ type InvalidAddForm = {
 };
 
 export type AddFormValidationResult = ValidAddForm | InvalidAddForm;
+
+type InitialFormFilters = {
+  accountId: string;
+  categoryId: string;
+  dateFrom: string;
+};
+
+export function buildInitialAddForm(filters: InitialFormFilters): AddFormState {
+  return {
+    accountId: filters.accountId,
+    categoryId: filters.categoryId || UNCATEGORIZED_VALUE,
+    bookingDate: filters.dateFrom,
+    amountNok: "",
+    merchant: "",
+    paymentType: "OTHER",
+    note: "",
+  };
+}
+
+export function isFutureDate(dateStr: string): boolean {
+  if (!dateStr) return false;
+  const today = new Date().toISOString().slice(0, 10);
+  return dateStr > today;
+}
 
 export function validateAddForm(form: AddFormState): AddFormValidationResult {
   const accountId = form.accountId.trim();

--- a/src/app/transactions/components/add-transaction-dialog.tsx
+++ b/src/app/transactions/components/add-transaction-dialog.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { MAX_TRANSACTION_NOTE_LENGTH } from "@/lib/transactions/note";
+import { isFutureDate } from "../add-transaction-form";
 import {
   type Account,
   type AddFormState,
@@ -112,6 +113,11 @@ export function AddTransactionDialog({
                   onChange={(event) => onBookingDateChange(event.target.value)}
                   disabled={addSaving}
                 />
+                {isFutureDate(addForm.bookingDate) ? (
+                  <p className="text-warning text-xs">
+                    This date is in the future.
+                  </p>
+                ) : null}
               </FieldContent>
             </Field>
 

--- a/src/app/transactions/transactions-manager.tsx
+++ b/src/app/transactions/transactions-manager.tsx
@@ -7,7 +7,7 @@ import {
   MAX_TRANSACTION_NOTE_LENGTH,
   MAX_TRANSACTION_NOTE_LENGTH_MESSAGE,
 } from "@/lib/transactions/note";
-import { validateAddForm } from "./add-transaction-form";
+import { buildInitialAddForm, validateAddForm } from "./add-transaction-form";
 import { AddTransactionDialog } from "./components/add-transaction-dialog";
 import { BulkDeleteTransactionsDialog } from "./components/bulk-delete-transactions-dialog";
 import { DeleteTransactionDialog } from "./components/delete-transaction-dialog";
@@ -151,17 +151,9 @@ export function TransactionsManager() {
   }, []);
 
   const openAddDialog = useCallback(() => {
-    setAddForm({
-      accountId: "",
-      categoryId: UNCATEGORIZED_VALUE,
-      bookingDate: "",
-      amountNok: "",
-      merchant: "",
-      paymentType: "OTHER",
-      note: "",
-    });
+    setAddForm(buildInitialAddForm({ accountId, categoryId, dateFrom }));
     setAddError(null);
-  }, []);
+  }, [accountId, categoryId, dateFrom]);
 
   async function handleAddSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();


### PR DESCRIPTION
## Summary

- Pre-fills Account, Category, and Booking Date fields in the Add Transaction dialog based on active URL filter state (`accountId`, `categoryId`, `dateFrom`)
- Shows a passive inline warning below the date input when `bookingDate` is in the future — does not block submission
- Adds `buildInitialAddForm()` and `isFutureDate()` pure utilities with 11 new unit tests

## Test plan

- [ ] With an account filter active, open the dialog — Account field is pre-filled
- [ ] With a category filter active, open the dialog — Category field is pre-filled
- [ ] With a dateFrom filter active, open the dialog — Booking Date field is pre-filled
- [ ] All pre-filled fields can be edited before submitting
- [ ] Selecting a future date shows an amber warning below the date input
- [ ] The warning does not prevent form submission
- [ ] \`pnpm run lint\` passes
- [ ] \`pnpm run typecheck\` passes
- [ ] \`pnpm exec vitest run\` — 221 tests pass

Closes #21