### PR TITLE
feat(transactions): redesign filter bar and table actions UI

### DIFF
--- a/src/app/transactions/components/transactions-table-section.tsx
+++ b/src/app/transactions/components/transactions-table-section.tsx
@@ -8,25 +8,27 @@ import {
   useReactTable,
   type VisibilityState,
 } from "@tanstack/react-table";
+import { format, parseISO } from "date-fns";
 import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
+  Calendar as CalendarIcon,
   ChevronLeft,
   ChevronRight,
-  ChevronsLeft,
-  ChevronsRight,
   Columns3,
   Ellipsis,
   FileText,
   Pencil,
   Plus,
+  Search,
   Trash2,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CategoryBadge } from "@/components/category-badge";
 import { CategoryCombobox } from "@/components/category-combobox";
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
@@ -40,20 +42,19 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Pagination,
   PaginationContent,
-  PaginationEllipsis,
   PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
 } from "@/components/ui/pagination";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -433,23 +434,7 @@ export function TransactionsTableSection({
       columnHelper.display({
         id: "actions",
         enableHiding: false,
-        header: ({ table }) => {
-          const selectedIds = Object.keys(table.getState().rowSelection);
-          if (selectedIds.length === 0)
-            return <span className="sr-only">Actions</span>;
-          return (
-            <Button
-              type="button"
-              variant="outline"
-              size="icon-sm"
-              aria-label={`Delete ${selectedIds.length} selected transaction${selectedIds.length !== 1 ? "s" : ""}`}
-              title={`Delete ${selectedIds.length} selected`}
-              onClick={() => onBulkDelete(selectedIds)}
-            >
-              <Trash2 className="h-4 w-4" aria-hidden="true" />
-            </Button>
-          );
-        },
+        header: () => <span className="sr-only">Actions</span>,
         cell: (info) => {
           const row = info.row.original;
 
@@ -491,7 +476,7 @@ export function TransactionsTableSection({
         },
       }),
     ],
-    [sortableHeader, onEdit, onDelete, onBulkDelete],
+    [sortableHeader, onEdit, onDelete],
   );
 
   const table = useReactTable({
@@ -546,113 +531,223 @@ export function TransactionsTableSection({
 
   return (
     <section className="space-y-2" aria-live="polite">
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-        <div className="space-y-2">
-          <Label htmlFor="transactions-global-query">Search</Label>
-          <Input
-            id="transactions-global-query"
-            type="search"
-            value={globalQuery}
-            onChange={(event) => onGlobalQueryChange(event.target.value)}
-            placeholder="Search merchant or notes..."
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="transactions-date-from">Date from</Label>
-          <Input
-            id="transactions-date-from"
-            type="date"
-            value={dateFrom}
-            onChange={(event) => onDateFromChange(event.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="transactions-date-to">Date to</Label>
-          <Input
-            id="transactions-date-to"
-            type="date"
-            value={dateTo}
-            onChange={(event) => onDateToChange(event.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="transactions-account-filter">Account</Label>
-          <Select
-            value={accountId || ALL_ACCOUNTS_VALUE}
-            onValueChange={(value) =>
-              onAccountFilterChange(value === ALL_ACCOUNTS_VALUE ? "" : value)
-            }
-          >
-            <SelectTrigger id="transactions-account-filter" className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL_ACCOUNTS_VALUE}>All accounts</SelectItem>
-              {accounts.map((account) => (
-                <SelectItem key={account.id} value={account.id}>
-                  {account.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="transactions-category-filter">Category</Label>
-          <CategoryCombobox
-            id="transactions-category-filter"
-            value={categoryId}
-            categories={categories}
-            onValueChange={(value) => onCategoryFilterChange(value)}
-            placeholder="All categories"
-            emptyLabel="No matching categories."
-            showClear
-          />
-        </div>
-      </div>
+      {/* Filters and Actions Card */}
+      <div className="rounded-xl border border-border p-4">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="min-w-50 flex-1">
+            <label
+              htmlFor="transactions-global-query"
+              className="mb-1.5 block font-medium text-muted-foreground text-xs"
+            >
+              Search
+            </label>
+            <div className="relative">
+              <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="transactions-global-query"
+                type="search"
+                value={globalQuery}
+                onChange={(event) => onGlobalQueryChange(event.target.value)}
+                placeholder="Search merchant or notes..."
+                className="h-9 bg-background pl-9"
+              />
+            </div>
+          </div>
 
-      <div className="flex justify-end gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          className="gap-2"
-          onClick={onAdd}
-        >
-          <Plus className="h-4 w-4" aria-hidden="true" />
-          Add transaction
-        </Button>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button type="button" variant="outline" className="gap-2">
-              <Columns3 className="h-4 w-4" aria-hidden="true" />
-              Columns
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {visibleColumns.map((column) => (
-              <DropdownMenuCheckboxItem
-                key={column.id}
-                checked={column.getIsVisible()}
-                onCheckedChange={(checked) =>
-                  column.toggleVisibility(Boolean(checked))
-                }
+          <div className="flex gap-2">
+            <div>
+              <label
+                htmlFor="transactions-date-from"
+                className="mb-1.5 block font-medium text-muted-foreground text-xs"
               >
-                {COLUMN_LABELS[column.id] ?? column.id}
-              </DropdownMenuCheckboxItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+                Date from
+              </label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    id="transactions-date-from"
+                    variant="outline"
+                    className={cn(
+                      "h-9 w-35 justify-start bg-background text-left font-normal",
+                      !dateFrom && "text-muted-foreground",
+                    )}
+                  >
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {dateFrom
+                      ? format(parseISO(dateFrom), "dd/MM/yyyy")
+                      : "Pick date"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={dateFrom ? parseISO(dateFrom) : undefined}
+                    onSelect={(date) =>
+                      onDateFromChange(date ? format(date, "yyyy-MM-dd") : "")
+                    }
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+
+            <div>
+              <label
+                htmlFor="transactions-date-to"
+                className="mb-1.5 block font-medium text-muted-foreground text-xs"
+              >
+                Date to
+              </label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    id="transactions-date-to"
+                    variant="outline"
+                    className={cn(
+                      "h-9 w-35 justify-start bg-background text-left font-normal",
+                      !dateTo && "text-muted-foreground",
+                    )}
+                  >
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {dateTo
+                      ? format(parseISO(dateTo), "dd/MM/yyyy")
+                      : "Pick date"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={dateTo ? parseISO(dateTo) : undefined}
+                    onSelect={(date) =>
+                      onDateToChange(date ? format(date, "yyyy-MM-dd") : "")
+                    }
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="transactions-account-filter"
+              className="mb-1.5 block font-medium text-muted-foreground text-xs"
+            >
+              Account
+            </label>
+            <Select
+              value={accountId || ALL_ACCOUNTS_VALUE}
+              onValueChange={(value) =>
+                onAccountFilterChange(value === ALL_ACCOUNTS_VALUE ? "" : value)
+              }
+            >
+              <SelectTrigger
+                id="transactions-account-filter"
+                className="h-9 w-40 bg-background"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_ACCOUNTS_VALUE}>All accounts</SelectItem>
+                {accounts.map((account) => (
+                  <SelectItem key={account.id} value={account.id}>
+                    {account.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="transactions-category-filter"
+              className="mb-1.5 block font-medium text-muted-foreground text-xs"
+            >
+              Category
+            </label>
+            <CategoryCombobox
+              id="transactions-category-filter"
+              value={categoryId}
+              categories={categories}
+              onValueChange={(value) => onCategoryFilterChange(value)}
+              placeholder="All categories"
+              emptyLabel="No matching categories."
+              showClear
+            />
+          </div>
+        </div>
       </div>
 
-      <p className="text-muted-foreground text-sm">
-        {transactions.pagination.total} total transactions.
-      </p>
+      {/* Table Info & Actions */}
+      <div className="mt-8 flex items-center justify-between">
+        <span className="text-muted-foreground text-sm">
+          {Object.keys(rowSelection).length > 0 ? (
+            <>
+              <span className="font-medium text-foreground">
+                {Object.keys(rowSelection).length}
+              </span>{" "}
+              of {transactions.pagination.total} selected
+            </>
+          ) : (
+            <>
+              {transactions.pagination.total} total transactions.
+              {loading ? " Updating..." : null}
+            </>
+          )}
+        </span>
 
-      {loading ? (
-        <p className="text-muted-foreground text-sm">Updating results...</p>
-      ) : null}
+        <div className="flex items-center gap-2">
+          {Object.keys(rowSelection).length > 0 && (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-2 text-destructive hover:text-destructive"
+                onClick={() => onBulkDelete(Object.keys(rowSelection))}
+              >
+                <Trash2 className="h-4 w-4" aria-hidden="true" />
+                Delete
+              </Button>
+              <div className="mx-1 h-4 w-px bg-border" />
+            </>
+          )}
 
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-2"
+              >
+                <Columns3 className="h-4 w-4" aria-hidden="true" />
+                Columns
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {visibleColumns.map((column) => (
+                <DropdownMenuCheckboxItem
+                  key={column.id}
+                  checked={column.getIsVisible()}
+                  onCheckedChange={(checked) =>
+                    column.toggleVisibility(Boolean(checked))
+                  }
+                >
+                  {COLUMN_LABELS[column.id] ?? column.id}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <Button type="button" size="sm" className="gap-2" onClick={onAdd}>
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Add transaction
+          </Button>
+        </div>
+      </div>
+
+      {/* Transactions Table */}
       {transactions.rows.length === 0 ? (
         <p className="text-muted-foreground text-sm">
           {hasActiveFilters
@@ -660,7 +755,7 @@ export function TransactionsTableSection({
             : "No transactions found."}
         </p>
       ) : (
-        <div className="rounded-xl border border-border">
+        <div className="mt-4 rounded-xl border border-border">
           <Table>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (

--- a/src/app/transactions/components/transactions-table-section.tsx
+++ b/src/app/transactions/components/transactions-table-section.tsx
@@ -38,11 +38,22 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -62,6 +73,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { formatNok } from "@/lib/format-nok";
+import { cn } from "@/lib/utils";
 import {
   type Account,
   ALL_ACCOUNTS_VALUE,
@@ -134,11 +146,11 @@ function getHeaderClassName(columnId: string) {
 
 function getCellClassName(columnId: string) {
   if (columnId === "select" || columnId === "noteIndicator") {
-    return "w-0";
+    return "w-12";
   }
 
-  if (columnId === "amountNok" || columnId === "actions") {
-    return "text-right";
+  if (columnId === "amountNok") {
+    return "text-right tabular-nums font-mono";
   }
 
   return undefined;
@@ -228,7 +240,9 @@ export function TransactionsTableSection({
     pageIndex: currentPage - 1,
     pageSize,
   };
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
+    paymentType: false,
+  });
   const [hasHydratedColumnVisibility, setHasHydratedColumnVisibility] =
     useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -407,7 +421,14 @@ export function TransactionsTableSection({
       columnHelper.accessor("amountNok", {
         enableHiding: true,
         header: () => sortableHeader("Amount", "amountNok"),
-        cell: (info) => formatNok(info.getValue()),
+        cell: (info) => {
+          const value = info.getValue();
+          return (
+            <span className={cn(value > 0 && "text-success")}>
+              {formatNok(info.getValue())}
+            </span>
+          );
+        },
       }),
       columnHelper.display({
         id: "actions",
@@ -437,7 +458,8 @@ export function TransactionsTableSection({
               <DropdownMenuTrigger asChild>
                 <Button
                   type="button"
-                  variant="outline"
+                  variant="ghost"
+                  className="invisible cursor-pointer group-hover/row:visible"
                   size="icon-sm"
                   aria-label={`Actions for transaction from ${row.bookingDate}`}
                   title={`Actions for transaction from ${row.bookingDate}`}
@@ -532,7 +554,7 @@ export function TransactionsTableSection({
             type="search"
             value={globalQuery}
             onChange={(event) => onGlobalQueryChange(event.target.value)}
-            placeholder="Search merchant or note"
+            placeholder="Search merchant or notes..."
           />
         </div>
         <div className="space-y-2">
@@ -638,11 +660,11 @@ export function TransactionsTableSection({
             : "No transactions found."}
         </p>
       ) : (
-        <>
+        <div className="rounded-xl border border-border">
           <Table>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id}>
+                <TableRow className="bg-muted/30" key={headerGroup.id}>
                   {headerGroup.headers.map((header) => (
                     <TableHead
                       key={header.id}
@@ -659,9 +681,9 @@ export function TransactionsTableSection({
                 </TableRow>
               ))}
             </TableHeader>
-            <TableBody>
+            <TableBody className="[&_tr:last-child]:border-b">
               {table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
+                <TableRow className="group/row" key={row.id}>
                   {row.getVisibleCells().map((cell) => (
                     <TableCell
                       key={cell.id}
@@ -678,20 +700,19 @@ export function TransactionsTableSection({
             </TableBody>
           </Table>
 
-          <div className="flex w-full justify-center sm:justify-end">
-            <div className="flex flex-col items-center gap-2 text-foreground text-sm sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
-              <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">Rows per page:</span>
+          <div className="flex w-full justify-center p-2 sm:justify-end">
+            <div className="flex items-center justify-between gap-4">
+              <Field orientation="horizontal" className="w-fit">
+                <FieldLabel htmlFor="select-rows-per-page">
+                  Rows per page
+                </FieldLabel>
                 <Select
                   value={String(pageSize)}
                   onValueChange={(value) =>
                     onPageSizeChange(Number.parseInt(value, 10))
                   }
                 >
-                  <SelectTrigger
-                    id="transactions-rows-per-page"
-                    className="h-8 w-21"
-                  >
+                  <SelectTrigger id="transactions-rows-per-page">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -702,55 +723,40 @@ export function TransactionsTableSection({
                     ))}
                   </SelectContent>
                 </Select>
-              </div>
-              <span>
-                Page {table.getState().pagination.pageIndex + 1} of {totalPages}
-              </span>
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon-sm"
-                  aria-label="Go to first page"
-                  onClick={() => table.setPageIndex(0)}
-                  disabled={loading || !table.getCanPreviousPage()}
-                >
-                  <ChevronsLeft className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon-sm"
-                  aria-label="Go to previous page"
-                  onClick={() => table.previousPage()}
-                  disabled={loading || !table.getCanPreviousPage()}
-                >
-                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon-sm"
-                  aria-label="Go to next page"
-                  onClick={() => table.nextPage()}
-                  disabled={loading || !table.getCanNextPage()}
-                >
-                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon-sm"
-                  aria-label="Go to last page"
-                  onClick={() => table.setPageIndex(totalPages - 1)}
-                  disabled={loading || !table.getCanNextPage()}
-                >
-                  <ChevronsRight className="h-4 w-4" aria-hidden="true" />
-                </Button>
-              </div>
+              </Field>
+              <Pagination className="mx-0 w-auto">
+                <PaginationContent>
+                  <PaginationItem>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      aria-label="Go to previous page"
+                      className="cursor-pointer"
+                      onClick={() => table.previousPage()}
+                      disabled={loading || !table.getCanPreviousPage()}
+                    >
+                      <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                      Previous
+                    </Button>
+                  </PaginationItem>
+                  <PaginationItem>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      aria-label="Go to next page"
+                      className="cursor-pointer"
+                      onClick={() => table.nextPage()}
+                      disabled={loading || !table.getCanNextPage()}
+                    >
+                      Next{" "}
+                      <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
             </div>
           </div>
-        </>
+        </div>
       )}
     </section>
   );

--- a/src/app/transactions/transactions-manager.tsx
+++ b/src/app/transactions/transactions-manager.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import { Separator } from "@/components/ui/separator";
 import {
   MAX_TRANSACTION_NOTE_LENGTH,
   MAX_TRANSACTION_NOTE_LENGTH_MESSAGE,
@@ -339,8 +338,6 @@ export function TransactionsManager() {
           {error}
         </p>
       ) : null}
-
-      <Separator className="my-4" />
 
       <TransactionsTableSection
         loading={loading}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,12 +1,12 @@
-import * as React from "react"
+import * as React from "react";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
   MoreHorizontalIcon,
-} from "lucide-react"
+} from "lucide-react";
 
-import { cn } from "@/lib/utils"
-import { buttonVariants, type Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { buttonVariants, type Button } from "@/components/ui/button";
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
   return (
@@ -17,7 +17,7 @@ function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
       className={cn("mx-auto flex w-full justify-center", className)}
       {...props}
     />
-  )
+  );
 }
 
 function PaginationContent({
@@ -30,17 +30,17 @@ function PaginationContent({
       className={cn("flex flex-row items-center gap-1", className)}
       {...props}
     />
-  )
+  );
 }
 
 function PaginationItem({ ...props }: React.ComponentProps<"li">) {
-  return <li data-slot="pagination-item" {...props} />
+  return <li data-slot="pagination-item" {...props} />;
 }
 
 type PaginationLinkProps = {
-  isActive?: boolean
+  isActive?: boolean;
 } & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+  React.ComponentProps<"a">;
 
 function PaginationLink({
   className,
@@ -58,11 +58,11 @@ function PaginationLink({
           variant: isActive ? "outline" : "ghost",
           size,
         }),
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function PaginationPrevious({
@@ -79,7 +79,7 @@ function PaginationPrevious({
       <ChevronLeftIcon />
       <span className="hidden sm:block">Previous</span>
     </PaginationLink>
-  )
+  );
 }
 
 function PaginationNext({
@@ -96,7 +96,7 @@ function PaginationNext({
       <span className="hidden sm:block">Next</span>
       <ChevronRightIcon />
     </PaginationLink>
-  )
+  );
 }
 
 function PaginationEllipsis({
@@ -113,7 +113,7 @@ function PaginationEllipsis({
       <MoreHorizontalIcon className="size-4" />
       <span className="sr-only">More pages</span>
     </span>
-  )
+  );
 }
 
 export {
@@ -124,4 +124,4 @@ export {
   PaginationPrevious,
   PaginationNext,
   PaginationEllipsis,
-}
+};

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants, type Button } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}


### PR DESCRIPTION
## Summary

- Wraps filters in a card (`rounded-xl border bg-card p-4`) with `flex-wrap` layout and per-filter labels
- Replaces native `<input type="date">` with shadcn `Calendar` + `Popover` date pickers (date-fns for string↔Date conversion)
- Adds search icon overlay to search input
- Replaces the separate buttons row + count paragraph with a unified info/actions bar: left shows total count or "X of N selected"; right shows bulk Delete + separator conditionally, then Columns (outline sm) and Add transaction (filled primary sm)
- Removes the redundant bulk delete button from the table actions column header

## Test plan

- [ ] Filters card renders correctly; all filters still work and sync to URL
- [ ] Date pickers open calendar popover; selected dates display as `dd/MM/yyyy` and filter correctly
- [ ] Search icon visible in search input
- [ ] Info bar shows correct total count
- [ ] Selecting rows shows "X of N selected" and reveals Delete button
- [ ] Bulk delete via bar button works
- [ ] Columns dropdown toggles column visibility
- [ ] Add transaction opens dialog