### PR TITLE
feat(dashboard): remove all-time preset, default to last 30 days

### DIFF
--- a/src/app/(overview)/overview-dashboard.tsx
+++ b/src/app/(overview)/overview-dashboard.tsx
@@ -112,13 +112,6 @@ export function OverviewDashboard() {
           </p>
           <ButtonGroup role="group" aria-labelledby="date-range-label">
             <Button
-              variant={dashboardRangePreset === "all" ? "default" : "outline"}
-              onClick={() => setDashboardPreset("all")}
-              aria-pressed={dashboardRangePreset === "all"}
-            >
-              All time
-            </Button>
-            <Button
               variant={dashboardRangePreset === "30d" ? "default" : "outline"}
               onClick={() => setDashboardPreset("30d")}
               aria-pressed={dashboardRangePreset === "30d"}

--- a/src/app/(overview)/overview-dashboard.types.ts
+++ b/src/app/(overview)/overview-dashboard.types.ts
@@ -3,7 +3,7 @@ export type Account = {
   name: string;
 };
 
-export type DashboardRangePreset = "all" | "30d" | "90d" | "ytd" | "custom";
+export type DashboardRangePreset = "30d" | "90d" | "ytd" | "custom";
 
 export type DashboardAnalytics = {
   netCashflow: Array<{

--- a/src/app/(overview)/overview-dashboard.utils.test.ts
+++ b/src/app/(overview)/overview-dashboard.utils.test.ts
@@ -6,13 +6,6 @@ describe("overview dashboard date presets", () => {
     vi.useRealTimers();
   });
 
-  it("returns an unbounded range for the all-time preset", () => {
-    expect(getPresetRange("all")).toEqual({
-      startDate: "",
-      endDate: "",
-    });
-  });
-
   it("keeps 30-day range deterministic against the current day", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-20T12:00:00.000Z"));

--- a/src/app/(overview)/overview-dashboard.utils.ts
+++ b/src/app/(overview)/overview-dashboard.utils.ts
@@ -70,13 +70,6 @@ export function fromDateInputValue(value: string) {
 export function getPresetRange(
   preset: Exclude<DashboardRangePreset, "custom">,
 ) {
-  if (preset === "all") {
-    return {
-      startDate: "",
-      endDate: "",
-    };
-  }
-
   const endDate = new Date();
   endDate.setHours(0, 0, 0, 0);
   const startDate = new Date(endDate);

--- a/src/app/(overview)/use-overview-dashboard.ts
+++ b/src/app/(overview)/use-overview-dashboard.ts
@@ -30,12 +30,12 @@ export function useOverviewDashboard(): UseOverviewDashboardResult {
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [dashboardAccountId, setDashboardAccountId] = useState("");
   const [dashboardRangePreset, setDashboardRangePreset] =
-    useState<DashboardRangePreset>("all");
+    useState<DashboardRangePreset>("30d");
   const [dashboardStartDate, setDashboardStartDate] = useState(
-    () => getPresetRange("all").startDate,
+    () => getPresetRange("30d").startDate,
   );
   const [dashboardEndDate, setDashboardEndDate] = useState(
-    () => getPresetRange("all").endDate,
+    () => getPresetRange("30d").endDate,
   );
   const [dashboardLoading, setDashboardLoading] = useState(true);
   const [dashboardError, setDashboardError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- Removes the "All time" button from the dashboard date range selector
- Changes the default preset from "all" to "last 30 days"
- Removes `"all"` from the `DashboardRangePreset` type and cleans up the associated `getPresetRange` branch and test