### PR TITLE
fix: show categories in combobox on open and filter by name

### DIFF
--- a/src/components/category-combobox.tsx
+++ b/src/components/category-combobox.tsx
@@ -54,6 +54,12 @@ export function CategoryCombobox({
       itemToStringLabel={(itemValue) =>
         categoriesById.get(itemValue as string) ?? (itemValue as string)
       }
+      filter={(inputValue, categoryId) => {
+        if (!inputValue) return true;
+        const name =
+          categoriesById.get(categoryId as string) ?? String(categoryId);
+        return name.toLowerCase().includes(inputValue.toLowerCase());
+      }}
       autoHighlight
       disabled={disabled}
       modal={false}


### PR DESCRIPTION
## Summary

Fixes #28 — reported by @Shtian

The category combobox in the new transaction modal was broken in two ways:

- **No items on first open**: The `@base-ui/react` Combobox has a "pristine" state where no items are shown until the user has interacted with the input. This caused the dropdown to appear empty when first opened.
- **Typing showed nothing**: The default filter compared the input text against raw item values (category IDs like `"abc123"`) rather than the human-readable category names. So typing `"Mat"` would never match `"Matvarer"` because no ID contains that string. Only after clearing the input (empty string matches all IDs) would items reappear.

## Fix

Added a custom `filter` prop to the `Combobox` in `CategoryCombobox`:

```tsx
filter={(inputValue, categoryId) => {
  if (!inputValue) return true;
  const name = categoriesById.get(categoryId as string) ?? String(categoryId);
  return name.toLowerCase().includes(inputValue.toLowerCase());
}}
```

- When input is empty → show all categories (fixes first-open blank state)
- When input is non-empty → match against category **names** (fixes search not working)

## Test plan

- [ ] Open the "Add transaction" modal
- [ ] Click the Category field — all categories should be visible immediately
- [ ] Type part of a category name (e.g. `"Mat"`) — matching categories (e.g. `"Matvarer"`) should appear
- [ ] Clear the input — all categories should reappear
- [ ] Verify the same behaviour holds in the "Edit transaction" modal (uses the same `CategoryCombobox` component)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKNZy2VeivKfkmtyxsAu4)_