### PR TITLE
feat: add account column to transactions table

### DIFF
--- a/src/app/transactions/components/transactions-table-section.tsx
+++ b/src/app/transactions/components/transactions-table-section.tsx
@@ -90,6 +90,7 @@ const COLUMN_VISIBILITY_STORAGE_KEY =
 const HIDEABLE_COLUMN_IDS = [
   "bookingDate",
   "merchant",
+  "account",
   "category",
   "paymentType",
   "amountNok",
@@ -97,6 +98,7 @@ const HIDEABLE_COLUMN_IDS = [
 const COLUMN_LABELS: Record<string, string> = {
   bookingDate: "Date",
   merchant: "Merchant",
+  account: "Account",
   paymentType: "Payment type",
   amountNok: "Amount",
   category: "Category",
@@ -243,6 +245,7 @@ export function TransactionsTableSection({
   };
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     paymentType: false,
+    account: false,
   });
   const [hasHydratedColumnVisibility, setHasHydratedColumnVisibility] =
     useState(false);
@@ -403,6 +406,12 @@ export function TransactionsTableSection({
             </TooltipProvider>
           );
         },
+      }),
+      columnHelper.accessor("accountName", {
+        id: "account",
+        enableHiding: true,
+        header: "Account",
+        cell: (info) => info.getValue(),
       }),
       columnHelper.display({
         id: "category",

--- a/src/app/transactions/transactions-manager.types.ts
+++ b/src/app/transactions/transactions-manager.types.ts
@@ -12,6 +12,7 @@ export type Category = {
 export type TransactionRow = {
   id: string;
   accountId: string;
+  accountName: string;
   categoryId: string | null;
   categoryName: string | null;
   bookingDate: string;

--- a/src/lib/transactions/create.test.ts
+++ b/src/lib/transactions/create.test.ts
@@ -9,6 +9,9 @@ function createDbMock() {
       create: vi.fn(async () => ({
         id: "tx-new",
         accountId: "acc-1",
+        account: {
+          name: "Test Account",
+        },
         categoryId: "cat-1",
         category: {
           name: "Groceries",
@@ -223,6 +226,11 @@ describe("createTransaction", () => {
       select: {
         id: true,
         accountId: true,
+        account: {
+          select: {
+            name: true,
+          },
+        },
         categoryId: true,
         category: {
           select: {
@@ -244,6 +252,7 @@ describe("createTransaction", () => {
     expect(transaction).toEqual({
       id: "tx-new",
       accountId: "acc-1",
+      accountName: "Test Account",
       categoryId: "cat-1",
       categoryName: "Groceries",
       bookingDate: "2026-03-01",

--- a/src/lib/transactions/create.ts
+++ b/src/lib/transactions/create.ts
@@ -11,6 +11,9 @@ type DecimalLike = { toString(): string } | number;
 type TransactionCreateRecord = {
   id: string;
   accountId: string;
+  account: {
+    name: string;
+  };
   categoryId: string | null;
   category: {
     name: string;
@@ -43,6 +46,11 @@ type TransactionCreateDbClient = {
       select: {
         id: true;
         accountId: true;
+        account: {
+          select: {
+            name: true;
+          };
+        };
         categoryId: true;
         category: {
           select: {
@@ -126,6 +134,7 @@ function toTransactionListRow(
   return {
     id: record.id,
     accountId: record.accountId,
+    accountName: record.account.name,
     categoryId: record.categoryId,
     categoryName: record.category?.name ?? null,
     bookingDate: record.bookingDate.toISOString().slice(0, 10),
@@ -165,6 +174,11 @@ export async function createTransaction(
     select: {
       id: true,
       accountId: true,
+      account: {
+        select: {
+          name: true,
+        },
+      },
       categoryId: true,
       category: {
         select: {

--- a/src/lib/transactions/list.test.ts
+++ b/src/lib/transactions/list.test.ts
@@ -9,6 +9,9 @@ function createTransactionsDbMock(total: number) {
         {
           id: "tx-2",
           accountId: "acc-1",
+          account: {
+            name: "Test Account",
+          },
           categoryId: "cat-1",
           category: {
             name: "Groceries",
@@ -57,6 +60,11 @@ describe("getTransactionsPage", () => {
       select: {
         id: true,
         accountId: true,
+        account: {
+          select: {
+            name: true,
+          },
+        },
         categoryId: true,
         category: {
           select: {
@@ -97,6 +105,7 @@ describe("getTransactionsPage", () => {
       {
         id: "tx-2",
         accountId: "acc-1",
+        accountName: "Test Account",
         categoryId: "cat-1",
         categoryName: "Groceries",
         bookingDate: "2026-02-04",

--- a/src/lib/transactions/list.ts
+++ b/src/lib/transactions/list.ts
@@ -9,6 +9,9 @@ type StringContainsFilter = {
 type TransactionListRecord = {
   id: string;
   accountId: string;
+  account: {
+    name: string;
+  };
   categoryId: string | null;
   category: {
     name: string;
@@ -32,6 +35,11 @@ type TransactionListDbClient = {
       select: {
         id: true;
         accountId: true;
+        account: {
+          select: {
+            name: true;
+          };
+        };
         categoryId: true;
         category: {
           select: {
@@ -72,6 +80,7 @@ export type TransactionsListFilters = {
 export type TransactionListRow = {
   id: string;
   accountId: string;
+  accountName: string;
   categoryId: string | null;
   categoryName: string | null;
   bookingDate: string;
@@ -182,6 +191,11 @@ export async function getTransactionsPage(
     select: {
       id: true,
       accountId: true,
+      account: {
+        select: {
+          name: true,
+        },
+      },
       categoryId: true,
       category: {
         select: {
@@ -206,6 +220,7 @@ export async function getTransactionsPage(
   const rows = records.map((record) => ({
     id: record.id,
     accountId: record.accountId,
+    accountName: record.account.name,
     categoryId: record.categoryId,
     categoryName: record.category?.name ?? null,
     bookingDate: record.bookingDate.toISOString().slice(0, 10),

--- a/src/lib/transactions/update.test.ts
+++ b/src/lib/transactions/update.test.ts
@@ -9,6 +9,9 @@ function createUpdateDbMock() {
       update: vi.fn(async () => ({
         id: "tx-1",
         accountId: "acc-1",
+        account: {
+          name: "Test Account",
+        },
         categoryId: "cat-1",
         category: {
           name: "Groceries",
@@ -154,6 +157,11 @@ describe("updateTransaction", () => {
       select: {
         id: true,
         accountId: true,
+        account: {
+          select: {
+            name: true,
+          },
+        },
         categoryId: true,
         category: {
           select: {
@@ -174,6 +182,7 @@ describe("updateTransaction", () => {
     expect(transaction).toEqual({
       id: "tx-1",
       accountId: "acc-1",
+      accountName: "Test Account",
       categoryId: "cat-1",
       categoryName: "Groceries",
       bookingDate: "2026-02-05",

--- a/src/lib/transactions/update.ts
+++ b/src/lib/transactions/update.ts
@@ -11,6 +11,9 @@ type DecimalLike = { toString(): string } | number;
 type TransactionUpdateRecord = {
   id: string;
   accountId: string;
+  account: {
+    name: string;
+  };
   categoryId: string | null;
   category: {
     name: string;
@@ -42,6 +45,11 @@ type TransactionUpdateDbClient = {
       select: {
         id: true;
         accountId: true;
+        account: {
+          select: {
+            name: true;
+          };
+        };
         categoryId: true;
         category: {
           select: {
@@ -144,6 +152,7 @@ function toTransactionListRow(
   return {
     id: record.id,
     accountId: record.accountId,
+    accountName: record.account.name,
     categoryId: record.categoryId,
     categoryName: record.category?.name ?? null,
     bookingDate: record.bookingDate.toISOString().slice(0, 10),
@@ -195,6 +204,11 @@ export async function updateTransaction(
     select: {
       id: true,
       accountId: true,
+      account: {
+        select: {
+          name: true,
+        },
+      },
       categoryId: true,
       category: {
         select: {


### PR DESCRIPTION
## Summary

Closes #30 — @Shtian

Adds an **Account** column to the transactions overview table, positioned between Merchant and Category as requested.

- The column is **hidden by default** and can be toggled via the Columns dropdown
- Fetches account name from the DB via a Prisma relation join in `getTransactionsPage`
- Adds `accountName: string` to `TransactionListRow` and `TransactionRow` types
- Updates `list.test.ts` to include `account` in the mock data and assert the new field in select/row-mapping expectations

## Changes

- `src/lib/transactions/list.ts` — select `account.name` in the Prisma query and map it to `accountName` on each row
- `src/app/transactions/transactions-manager.types.ts` — add `accountName: string` to `TransactionRow`
- `src/app/transactions/components/transactions-table-section.tsx` — add `account` column definition (between merchant and category), register it in `HIDEABLE_COLUMN_IDS`/`COLUMN_LABELS`, and default it to hidden
- `src/lib/transactions/list.test.ts` — update mock data and assertions for the new `account` select and `accountName` field

## Test plan

- [ ] Open the transactions page — Account column should not be visible by default
- [ ] Open the Columns dropdown — "Account" checkbox should be present and unchecked
- [ ] Check "Account" — column appears between Merchant and Category showing the account name for each row
- [ ] Uncheck "Account" — column hides again; visibility persists across page refreshes (sessionStorage)
- [ ] Unit tests pass: `src/lib/transactions/list.test.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_017c8BsouBaJMPzjSyiroyyu)_