### PR TITLE
feat: add gpt-5.4 model family and update model defaults

### DIFF
--- a/src/lib/import/message-cleanup-settings.test.ts
+++ b/src/lib/import/message-cleanup-settings.test.ts
@@ -41,7 +41,7 @@ describe("message cleanup settings", () => {
     expect(result).toEqual({
       prompt: DEFAULT_MESSAGE_CLEANUP_SYSTEM_PROMPT,
       isDefaultPrompt: true,
-      modelId: "gpt-5-mini",
+      modelId: "gpt-5.4-mini",
       isDefaultModel: true,
     });
   });
@@ -56,7 +56,7 @@ describe("message cleanup settings", () => {
     expect(result).toEqual({
       prompt: "Keep merchant names concise.",
       isDefaultPrompt: false,
-      modelId: "gpt-5-mini",
+      modelId: "gpt-5.4-mini",
       isDefaultModel: true,
     });
   });
@@ -71,7 +71,7 @@ describe("message cleanup settings", () => {
       resolvedPrompt: DEFAULT_MESSAGE_CLEANUP_SYSTEM_PROMPT,
       isDefaultPrompt: true,
       storedModelId: null,
-      resolvedModelId: "gpt-5-mini",
+      resolvedModelId: "gpt-5.4-mini",
       isDefaultModel: true,
     });
   });
@@ -112,15 +112,15 @@ describe("message cleanup settings", () => {
 
     const result = await updateMessageCleanupSettings(db, {
       promptText: "   ",
-      modelId: "gpt-5-mini",
+      modelId: "gpt-5.4-mini",
     });
 
     expect(result).toEqual({
       storedPromptText: null,
       resolvedPrompt: DEFAULT_MESSAGE_CLEANUP_SYSTEM_PROMPT,
       isDefaultPrompt: true,
-      storedModelId: "gpt-5-mini",
-      resolvedModelId: "gpt-5-mini",
+      storedModelId: "gpt-5.4-mini",
+      resolvedModelId: "gpt-5.4-mini",
       isDefaultModel: true,
     });
   });

--- a/src/lib/import/message-cleanup-settings.test.ts
+++ b/src/lib/import/message-cleanup-settings.test.ts
@@ -41,7 +41,7 @@ describe("message cleanup settings", () => {
     expect(result).toEqual({
       prompt: DEFAULT_MESSAGE_CLEANUP_SYSTEM_PROMPT,
       isDefaultPrompt: true,
-      modelId: "gpt-5.4-mini",
+      modelId: "gpt-5.4-nano",
       isDefaultModel: true,
     });
   });
@@ -56,7 +56,7 @@ describe("message cleanup settings", () => {
     expect(result).toEqual({
       prompt: "Keep merchant names concise.",
       isDefaultPrompt: false,
-      modelId: "gpt-5.4-mini",
+      modelId: "gpt-5.4-nano",
       isDefaultModel: true,
     });
   });
@@ -71,7 +71,7 @@ describe("message cleanup settings", () => {
       resolvedPrompt: DEFAULT_MESSAGE_CLEANUP_SYSTEM_PROMPT,
       isDefaultPrompt: true,
       storedModelId: null,
-      resolvedModelId: "gpt-5.4-mini",
+      resolvedModelId: "gpt-5.4-nano",
       isDefaultModel: true,
     });
   });
@@ -112,15 +112,15 @@ describe("message cleanup settings", () => {
 
     const result = await updateMessageCleanupSettings(db, {
       promptText: "   ",
-      modelId: "gpt-5.4-mini",
+      modelId: "gpt-5.4-nano",
     });
 
     expect(result).toEqual({
       storedPromptText: null,
       resolvedPrompt: DEFAULT_MESSAGE_CLEANUP_SYSTEM_PROMPT,
       isDefaultPrompt: true,
-      storedModelId: "gpt-5.4-mini",
-      resolvedModelId: "gpt-5.4-mini",
+      storedModelId: "gpt-5.4-nano",
+      resolvedModelId: "gpt-5.4-nano",
       isDefaultModel: true,
     });
   });

--- a/src/lib/import/message-cleanup-settings.ts
+++ b/src/lib/import/message-cleanup-settings.ts
@@ -4,7 +4,7 @@ import { getModelById } from "../monthly-review/chat-model-registry";
 const MESSAGE_CLEANUP_SETTINGS_ID = "message-cleanup-settings";
 
 export const DEFAULT_MESSAGE_CLEANUP_OPENAI_MODEL: OpenAIChatModelId =
-  "gpt-5.4-mini";
+  "gpt-5.4-nano";
 
 export const DEFAULT_MESSAGE_CLEANUP_SYSTEM_PROMPT =
   "You clean transaction messages. Return strict JSON with top-level suggestions only.";

--- a/src/lib/import/message-cleanup-settings.ts
+++ b/src/lib/import/message-cleanup-settings.ts
@@ -4,7 +4,7 @@ import { getModelById } from "../monthly-review/chat-model-registry";
 const MESSAGE_CLEANUP_SETTINGS_ID = "message-cleanup-settings";
 
 export const DEFAULT_MESSAGE_CLEANUP_OPENAI_MODEL: OpenAIChatModelId =
-  "gpt-5-mini";
+  "gpt-5.4-mini";
 
 export const DEFAULT_MESSAGE_CLEANUP_SYSTEM_PROMPT =
   "You clean transaction messages. Return strict JSON with top-level suggestions only.";

--- a/src/lib/monthly-review/chat-model-registry.test.ts
+++ b/src/lib/monthly-review/chat-model-registry.test.ts
@@ -8,10 +8,10 @@ import {
 
 describe("chat-model-registry", () => {
   it("resolves a known model by id", () => {
-    const model = getModelById("gpt-5.2");
+    const model = getModelById("gpt-5.4");
 
-    expect(model.id).toBe("gpt-5.2");
-    expect(model.label).toBe("GPT-5.2");
+    expect(model.id).toBe("gpt-5.4");
+    expect(model.label).toBe("GPT-5.4");
   });
 
   it("falls back safely for unknown model ids", () => {

--- a/src/lib/monthly-review/chat-model-registry.ts
+++ b/src/lib/monthly-review/chat-model-registry.ts
@@ -15,7 +15,7 @@ export type ChatModelEntry = {
   tier: ChatModelTier;
 };
 
-const DEFAULT_CHAT_MODEL_ID = "gpt-5.2" as const satisfies OpenAIChatModelId;
+const DEFAULT_CHAT_MODEL_ID = "gpt-5.4" as const satisfies OpenAIChatModelId;
 
 const CHAT_MODEL_METADATA_BY_ID = {
   "gpt-4.1-mini": {
@@ -33,14 +33,31 @@ const CHAT_MODEL_METADATA_BY_ID = {
     description: "Good quality with controlled cost for regular use.",
     tier: "balanced",
   },
-  [DEFAULT_CHAT_MODEL_ID]: {
+  "gpt-5.2": {
     label: "GPT-5.2",
-    description: "Best default quality/cost tradeoff for monthly analysis.",
+    description: "Solid quality/cost tradeoff for monthly analysis.",
     tier: "balanced",
   },
   "gpt-5.2-pro": {
     label: "GPT-5.2 Pro",
-    description: "Highest quality for deeper, more nuanced spending insights.",
+    description: "High quality for deeper, more nuanced spending insights.",
+    tier: "premium",
+  },
+  "gpt-5.4-mini": {
+    label: "GPT-5.4 Mini",
+    description:
+      "Fast and affordable, ideal for routine message cleanup and lightweight tasks.",
+    tier: "balanced",
+  },
+  [DEFAULT_CHAT_MODEL_ID]: {
+    label: "GPT-5.4",
+    description: "Best default quality/cost tradeoff for monthly analysis.",
+    tier: "balanced",
+  },
+  "gpt-5.4-pro": {
+    label: "GPT-5.4 Pro",
+    description:
+      "Highest quality for in-depth spending insights and complex analysis.",
     tier: "premium",
   },
 } as const satisfies Partial<Record<OpenAIChatModelId, ChatModelMetadata>>;

--- a/src/lib/monthly-review/chat-model-registry.ts
+++ b/src/lib/monthly-review/chat-model-registry.ts
@@ -43,6 +43,12 @@ const CHAT_MODEL_METADATA_BY_ID = {
     description: "High quality for deeper, more nuanced spending insights.",
     tier: "premium",
   },
+  "gpt-5.4-nano": {
+    label: "GPT-5.4 Nano",
+    description:
+      "Lowest cost, fastest response for simple message cleanup tasks.",
+    tier: "cheap",
+  },
   "gpt-5.4-mini": {
     label: "GPT-5.4 Mini",
     description:

--- a/src/lib/monthly-review/generation-input.test.ts
+++ b/src/lib/monthly-review/generation-input.test.ts
@@ -113,7 +113,7 @@ describe("buildMonthlyReviewGenerationInput", () => {
       monthStart: "2026-02-01",
       systemPrompt: "Focus on major spending shifts.",
       usesDefaultPrompt: false,
-      modelId: "gpt-5.2",
+      modelId: "gpt-5.4",
       usesDefaultModel: true,
       metrics: {
         monthlyTotals: {
@@ -216,7 +216,7 @@ describe("buildMonthlyReviewGenerationInput", () => {
 
     expect(result.systemPrompt).toBe(DEFAULT_MONTHLY_REVIEW_SYSTEM_PROMPT);
     expect(result.usesDefaultPrompt).toBe(true);
-    expect(result.modelId).toBe("gpt-5.2");
+    expect(result.modelId).toBe("gpt-5.4");
     expect(result.usesDefaultModel).toBe(true);
     expect(result.metrics.monthOverMonth).toBeNull();
     expect(result.metrics.categoryTotals).toEqual([

--- a/src/lib/monthly-review/system-prompt.test.ts
+++ b/src/lib/monthly-review/system-prompt.test.ts
@@ -42,7 +42,7 @@ describe("monthly review system prompt", () => {
     expect(result).toEqual({
       prompt: DEFAULT_MONTHLY_REVIEW_SYSTEM_PROMPT,
       isDefault: true,
-      modelId: "gpt-5.2",
+      modelId: "gpt-5.4",
       isDefaultModel: true,
     });
   });
@@ -55,7 +55,7 @@ describe("monthly review system prompt", () => {
     expect(result).toEqual({
       prompt: "Use structured bullet points.",
       isDefault: false,
-      modelId: "gpt-5.2",
+      modelId: "gpt-5.4",
       isDefaultModel: true,
     });
   });
@@ -70,7 +70,7 @@ describe("monthly review system prompt", () => {
       resolvedPrompt: DEFAULT_MONTHLY_REVIEW_SYSTEM_PROMPT,
       isDefault: true,
       storedModelId: null,
-      resolvedModelId: "gpt-5.2",
+      resolvedModelId: "gpt-5.4",
       isDefaultModel: true,
     });
   });
@@ -86,7 +86,7 @@ describe("monthly review system prompt", () => {
     expect(result).toEqual({
       prompt: "Focus on outliers and recurring merchants.",
       isDefault: false,
-      modelId: "gpt-5.2",
+      modelId: "gpt-5.4",
       isDefaultModel: true,
     });
     expect(db.monthlyReviewSystemPrompt.upsert).toHaveBeenCalledWith({
@@ -112,7 +112,7 @@ describe("monthly review system prompt", () => {
     expect(result).toEqual({
       prompt: DEFAULT_MONTHLY_REVIEW_SYSTEM_PROMPT,
       isDefault: true,
-      modelId: "gpt-5.2",
+      modelId: "gpt-5.4",
       isDefaultModel: true,
     });
     expect(db.monthlyReviewSystemPrompt.upsert).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary

Resolves #31 — @Shtian

- Added `gpt-5.4-nano`, `gpt-5.4-mini`, `gpt-5.4`, and `gpt-5.4-pro` to the chat model registry alongside the existing models
- Updated the **message cleanup** default model from `gpt-5-mini` → `gpt-5.4-nano` (latest nano model, lowest cost tier)
- Updated the **monthly review** default model from `gpt-5.2` → `gpt-5.4` (latest balanced-tier model)
- Kept `gpt-5.2` and `gpt-5.2-pro` in the registry so any users with those saved preferences are unaffected

## Model registry after this change

| Model | Tier |
|---|---|
| `gpt-4.1-mini` | cheap |
| `gpt-4o-mini` | cheap |
| `gpt-5.4-nano` ⭐ new default for message cleanup | cheap |
| `gpt-5-mini` | balanced |
| `gpt-5.2` | balanced |
| `gpt-5.4-mini` ⭐ new | balanced |
| `gpt-5.4` ⭐ new default for monthly review | balanced |
| `gpt-5.2-pro` | premium |
| `gpt-5.4-pro` ⭐ new | premium |

## Test plan

- [x] Lint passes (`pnpm lint`)
- [x] TypeScript passes (`pnpm exec tsc --noEmit`)
- [x] All 220 unit tests pass (`pnpm test:unit`)
- [x] Updated unit test assertions for new default model IDs in `message-cleanup-settings.test.ts`, `system-prompt.test.ts`, `generation-input.test.ts`, and `chat-model-registry.test.ts`

https://claude.ai/code/session_01XQSzpG3AavsXqfLUNNLbwZ